### PR TITLE
Another documentation typo

### DIFF
--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -31,7 +31,8 @@ Finishing up the setup requires the [WirtBot executable](https://github.com/b-m-
 
 This can be achieved with the following steps:
 
-- Download a release from https://github.com/b-m-f/wirt/releases and place it into `/usr/bin/wirtbot`
+- Download a release from https://github.com/b-m-f/wirt/releases and place it into `/usr/bin/`
+- `sudo chmod +x /usr/bin/wirtbot` to make it executable
 - Get the public key of your WirtUI from the [settings section](https://wirt.network/dashboard) on the Dashboard
 - Copy https://github.com/b-m-f/Wirt/blob/master/WirtBot/wirtbot.service to `/etc/systemd/system/wirtbot.service`
   - **Make sure to change the variables in that file**!

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -40,7 +40,7 @@ This can be achieved with the following steps:
   - SSL_KEY: this needs the location to your SSL key
   - User and Group: choose the user and the group that is used to run the `wirtbot` or delete these lines to use the root user.
   - You can leave the port and host setting at the default, unless you really know what you are doing
-- When configured correctly you can now run `systemctl enable --now wirtbit` to start the WirtBot. Use `journalctl -xe` if something is going wrong to get more information on what happened
+- When configured correctly you can now run `systemctl enable --now wirtbot` to start the WirtBot. Use `journalctl -xe` if something is going wrong to get more information on what happened
 - The last step to finish up the setup is the activation of a reloader. Copy https://github.com/b-m-f/Wirt/blob/master/WirtBot/wireguard-restarter.sh to `/usr/bin/wireguard-restarter.sh`
 - Now copy https://github.com/b-m-f/Wirt/blob/master/WirtBot/wireguard-restarter.service to `/etc/systemd/system/wireguard-restarter.service`
 - Run `systemctl enable --now wireguard-restarter`


### PR DESCRIPTION
`systemctl enable --now wirtbit` should be `systemctl enable --now wirtbot`

I also changed the docs to say to move the file into the `/usr/bin` directory rather than into `/usr/bin/wireguard` since the second one implies that it should be placed in a directory named `wireguard` in the bin directory, and not that the binary should be placed directly in the `/usr/bin` dir.

also added instructions to chmod the executable